### PR TITLE
Remove autodeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://github.com/capralifecycle/jenkins-slave
 
 ## Deploying new slaves
 
-We automatically deploy new slaves when a build succeeds. If a faulty
-slave is being deployed, no slaves might be available in Jenkins.
-A manual deploy can be done through AWS console and ECS, e.g. by
-using a previous task definition.
+New slave wrapper builds must be deloyed by following the procedure for
+https://github.com/capralifecycle/aws-infrastructure/tree/master/cloudformation/buildtools.
+
+See `jenkins.yml` in that repo for the different slaves we run.


### PR DESCRIPTION
Control version explictly by the configuration in aws-infrastructure
repo. In the future, we might automate the deploy of the infrastructure
setup and add back some autodeploy logic.

(This change matches https://github.com/capralifecycle/aws-infrastructure/commit/0192d2e81d70789206402de6aa084fb7320cd3ce)